### PR TITLE
pull descrs where they already existed

### DIFF
--- a/packages/charrua-core/charrua-core.0.4/descr
+++ b/packages/charrua-core/charrua-core.0.4/descr
@@ -1,0 +1,36 @@
+Charrua DHCP core library.
+
+[charrua-core](http://www.github.com/haesbaert/charrua-core) is an
+_ISC-licensed_ DHCP library implementation in ocaml.
+
+It provides basically two modules, a `Dhcp` responsible for parsing and
+constructing DHCP messages and a `Dhcp_server` module used for constructing DHCP
+servers.
+
+[charrua-unix](http://www.github.com/haesbaert/charrua-unix) is a Unix DHCP
+server based on charrua-core.
+
+[mirage](https://github.com/mirage/mirage-skeleton/tree/master/dhcp) is a Mirage
+DHCP unikernel server based on charrua-core.
+
+You can browse the API for [charrua-core] at
+http://haesbaert.github.io/charrua-core/api
+
+Features
+
+* Dhcp_server supports a stripped down ISC dhcpd.conf, so you can probably just
+  use your old dhcpd.conf, it also supports manual configuration building in
+  ocaml.
+* Logic/sequencing is agnostic of IO and platform, so it can run on Unix as a
+  process, as a Mirage unikernel or anything else.
+* Dhcp_wire provides marshalling and unmarshalling utilities for DHCP, it is the
+  base for Dhcp_server.
+* All DHCP options are supported at the time of this writing.
+* Code is purely applicative.
+* It's in ocaml, so it's pretty cool.
+
+The name `charrua` is a reference to the, now extinct, semi-nomadic people of
+southern South America.
+
+This project became one of the [Mirage Pioneer]
+(https://github.com/mirage/mirage-www/wiki/Pioneer-Projects) projects.

--- a/packages/conduit/conduit.0.15.0/descr
+++ b/packages/conduit/conduit.0.15.0/descr
@@ -1,0 +1,15 @@
+Network connection library for TCP and SSL
+
+The `conduit` library takes care of establishing and listening for TCP and
+SSL/TLS connections for the Lwt and Async libraries.
+
+The reason this library exists is to provide a degree of abstraction
+from the precise SSL library used, since there are a variety of ways to bind to
+a library (e.g. the C FFI, or the Ctypes library), as well as well as which
+library is used (either OpenSSL or a native OCaml TLS implementation).
+
+If you are using the `Lwt_unix` version of the library, you can set two
+environment variables to control the behaviour of the library:
+
+- `CONDUIT_DEBUG=1` will output debug information to standard error.
+- `CONDUIT_TLS=native` will force the use of the pure OCaml TLS library.

--- a/packages/crunch/crunch.2.0.0/descr
+++ b/packages/crunch/crunch.2.0.0/descr
@@ -1,0 +1,1 @@
+Convert a filesystem into a static OCaml module

--- a/packages/dns/dns.0.19.0/descr
+++ b/packages/dns/dns.0.19.0/descr
@@ -1,0 +1,5 @@
+DNS client and server implementation
+
+This is a pure OCaml implementation of the DNS protocol. It is intended to be a
+reasonably high-performance implementation, but clarity is preferred rather
+than low-level performance hacks.

--- a/packages/fat-filesystem/fat-filesystem.0.12.0/descr
+++ b/packages/fat-filesystem/fat-filesystem.0.12.0/descr
@@ -1,0 +1,1 @@
+FAT filesystem implementation

--- a/packages/functoria/functoria.2.0.0/descr
+++ b/packages/functoria/functoria.2.0.0/descr
@@ -1,0 +1,9 @@
+A DSL to organize functor applications.
+
+Functoria is a DSL to describe a set of modules and functors, their
+types and how to apply them in order to produce a complete
+application.
+
+The main use case is mirage. See the mirage repository for details:
+
+    https://github.com/mirage/mirage

--- a/packages/mirage-block-unix/mirage-block-unix.2.5.0/descr
+++ b/packages/mirage-block-unix/mirage-block-unix.2.5.0/descr
@@ -1,0 +1,1 @@
+MirageOS disk block driver for Unix

--- a/packages/mirage-block-xen/mirage-block-xen.1.5.0/descr
+++ b/packages/mirage-block-xen/mirage-block-xen.1.5.0/descr
@@ -1,0 +1,6 @@
+MirageOS block driver for Xen that implements the blkfront/back protocol
+
+This library allows
+  - MirageOS VMs to read and write disk data on Xen
+  - MirageOS VMs and userspace apps to act as disk servers for other VMs running
+    on the same Xen host

--- a/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.4.0/descr
+++ b/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.4.0/descr
@@ -1,0 +1,1 @@
+Library for reading MirageOS unikernel boot parameters in Xen

--- a/packages/mirage-clock-unix/mirage-clock-unix.1.2.0/descr
+++ b/packages/mirage-clock-unix/mirage-clock-unix.1.2.0/descr
@@ -1,0 +1,1 @@
+A Mirage-compatible Clock library for Unix

--- a/packages/mirage-conduit/mirage-conduit.2.3.0/descr
+++ b/packages/mirage-conduit/mirage-conduit.2.3.0/descr
@@ -1,0 +1,1 @@
+Virtual package for the MirageOS Conduit transports

--- a/packages/mirage-console-unix/mirage-console-unix.2.2.0/descr
+++ b/packages/mirage-console-unix/mirage-console-unix.2.2.0/descr
@@ -1,0 +1,1 @@
+A Mirage-compatible Console library for Unix

--- a/packages/mirage-console-xen/mirage-console-xen.2.2.0/descr
+++ b/packages/mirage-console-xen/mirage-console-xen.2.2.0/descr
@@ -1,0 +1,1 @@
+A Mirage-compatible Console library for Xen

--- a/packages/mirage-console/mirage-console.2.2.0/descr
+++ b/packages/mirage-console/mirage-console.2.2.0/descr
@@ -1,0 +1,1 @@
+A Mirage-compatible Console library for Xen and Unix

--- a/packages/mirage-dns/mirage-dns.2.6.0/descr
+++ b/packages/mirage-dns/mirage-dns.2.6.0/descr
@@ -1,0 +1,1 @@
+Virtual package for the MirageOS DNS transports

--- a/packages/mirage-flow/mirage-flow.1.2.0/descr
+++ b/packages/mirage-flow/mirage-flow.1.2.0/descr
@@ -1,0 +1,4 @@
+Various implementations of the MirageOS FLOW interface
+
+- `Fflow` uses input/output functions to build a flow
+- `Lwt_io_flow` uses `Lwt_io.channel`

--- a/packages/mirage-fs-unix/mirage-fs-unix.1.3.0/descr
+++ b/packages/mirage-fs-unix/mirage-fs-unix.1.3.0/descr
@@ -1,0 +1,1 @@
+MirageOS filesystem passthrough driver for Unix

--- a/packages/mirage-fs/mirage-fs.1.0.0/descr
+++ b/packages/mirage-fs/mirage-fs.1.0.0/descr
@@ -1,0 +1,1 @@
+MirageOS filesystem utilities

--- a/packages/mirage-http/mirage-http.3.0.0/descr
+++ b/packages/mirage-http/mirage-http.3.0.0/descr
@@ -1,0 +1,1 @@
+MirageOS HTTP client and server driver

--- a/packages/mirage-logs/mirage-logs.0.3.0/descr
+++ b/packages/mirage-logs/mirage-logs.0.3.0/descr
@@ -1,0 +1,5 @@
+A reporter for the Logs library that writes log messages to stderr, using a Mirage `CLOCK` to add timestamps.
+
+It can also log only important messages to the console, while writing all received messages to a ring buffer which is displayed if an exception occurs.
+
+If tracing is enabled (via mirage-profile), it also writes each log message to the trace buffer.

--- a/packages/mirage-net-macosx/mirage-net-macosx.1.3.0/descr
+++ b/packages/mirage-net-macosx/mirage-net-macosx.1.3.0/descr
@@ -1,0 +1,14 @@
+MacOS X implementation of the Mirage NETWORK interface.
+
+This interface exposes raw Ethernet frames using the
+[Vmnet](https://github.com/mirage/ocaml-vmnet) framework that
+is available on MacOS X Yosemite onwards.  It is suitable for
+use with an OCaml network stack such as the one found at
+<https://github.com/mirage/mirage-tcpip>.
+
+For a complete system that uses this, please see the
+[MirageOS](http://mirage.io) homepage.
+
+- docs: <https://mirage.github.io/mirage-net-macosx/>
+- Issues: <https://github.com/mirage/mirage-net-macosx/issues>
+- Email: <mirageos-devel@lists.xenproject.org>

--- a/packages/mirage-net-unix/mirage-net-unix.2.3.0/descr
+++ b/packages/mirage-net-unix/mirage-net-unix.2.3.0/descr
@@ -1,0 +1,1 @@
+Ethernet network driver for Mirage, using tuntap

--- a/packages/mirage-net-xen/mirage-net-xen.1.7.0/descr
+++ b/packages/mirage-net-xen/mirage-net-xen.1.7.0/descr
@@ -1,0 +1,8 @@
+Ethernet network device driver for MirageOS/Xen
+
+This library allows an OCaml application to read and
+write Ethernet frames via the `Netfront` protocol.
+
+* Web: <http://openmirage.org>
+* E-mail: <mirageos-devel@lists.xenproject.org>
+* Issues: <https://github.com/mirage/mirage/issues>

--- a/packages/mirage-net/mirage-net.1.0.0/descr
+++ b/packages/mirage-net/mirage-net.1.0.0/descr
@@ -1,0 +1,1 @@
+MirageOS TCP/IP networking library

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.0.0/descr
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.0.0/descr
@@ -1,0 +1,14 @@
+Lwt module type definitions for Mirage-compatible applications
+
+This is a virtual package that pulls in all the concrete
+dependencies required for the `mirage-types.lwt` ocamlfind
+package to become available.
+
+The purpose of this library is to provide concrete types
+for several that are left abstract in `mirage-types`:
+
+- `type 'a io = 'a Lwt.t`
+- `type page_aligned_buffer = Io_page.t`
+- `type buffer = Cstruct.t`
+- `type macaddr = Macaddr.t`
+- `type ipv4addr = Ipaddr.V4.t`

--- a/packages/mirage-types/mirage-types.3.0.0/descr
+++ b/packages/mirage-types/mirage-types.3.0.0/descr
@@ -1,0 +1,1 @@
+Module type definitions for Mirage-compatible applications

--- a/packages/mirage-unix/mirage-unix.3.0.0/descr
+++ b/packages/mirage-unix/mirage-unix.3.0.0/descr
@@ -1,0 +1,1 @@
+MirageOS platform library for UNIX compilation

--- a/packages/mirage-vnetif/mirage-vnetif.0.3/descr
+++ b/packages/mirage-vnetif/mirage-vnetif.0.3/descr
@@ -1,0 +1,6 @@
+Virtual network interface and software switch for Mirage.
+
+Provides the module Vnetif which can be used as a replacement for the
+regular Netif implementation in Xen and Unix. Stacks built using
+Vnetif are connected to a software switch that allows the stacks to
+communicate as if they were connected to the same LAN.

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.0/descr
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.0/descr
@@ -1,0 +1,3 @@
+MirageOS headers for the OCaml runtime
+
+The package contains the OCaml runtime patches and build system.

--- a/packages/mirage-xen/mirage-xen.3.0.0/descr
+++ b/packages/mirage-xen/mirage-xen.3.0.0/descr
@@ -1,0 +1,1 @@
+MirageOS library for Xen compilation

--- a/packages/mirage/mirage.3.0.0/descr
+++ b/packages/mirage/mirage.3.0.0/descr
@@ -1,0 +1,12 @@
+The MirageOS library operating system
+
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.

--- a/packages/tar-format/tar-format.0.7.0/descr
+++ b/packages/tar-format/tar-format.0.7.0/descr
@@ -1,0 +1,1 @@
+A pure OCaml library to read and write tar files

--- a/packages/tcpip/tcpip.3.0.0/descr
+++ b/packages/tcpip/tcpip.3.0.0/descr
@@ -1,0 +1,1 @@
+Userlevel TCP/IP stack

--- a/packages/vchan/vchan.2.3.0/descr
+++ b/packages/vchan/vchan.2.3.0/descr
@@ -1,0 +1,4 @@
+Xen Vchan implementation
+Vchan is a high performance inter-domain communications protocol using
+shared memory. This implementation runs in both userspace and
+kernelspace using Mirage.


### PR DESCRIPTION
Some packages are still `descr`-less after this; patch forthcoming.