### PR TITLE
use watermarked artifacts for topkg packages

### DIFF
--- a/packages/charrua-client/charrua-client.0.1.0/url
+++ b/packages/charrua-client/charrua-client.0.1.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/yomimono/charrua-client/archive/0.1.0.tar.gz"
-checksum: "68769922e9dcfd076e0eea384644db9f"
+archive: "https://github.com/yomimono/charrua-client/releases/download/0.1.0/charrua-client-0.1.0.tbz"
+checksum: "40932786184f5f8822ec9343a7775531"

--- a/packages/crunch/crunch.2.0.0/url
+++ b/packages/crunch/crunch.2.0.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/ocaml-crunch/archive/2.0.0.tar.gz"
-checksum: "990ae63798d87bc9aab7fcdcda7c63f0"
+archive: "https://github.com/mirage/ocaml-crunch/releases/download/2.0.0/crunch-2.0.0.tbz"
+checksum: "9764a599cbcb4ae4bce758f10d70cb8e"

--- a/packages/fat-filesystem/fat-filesystem.0.12.0/url
+++ b/packages/fat-filesystem/fat-filesystem.0.12.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/ocaml-fat/archive/0.12.0.tar.gz"
-checksum: "39b29df9cf1fe291001e804d159c271e"
+archive: "https://github.com/mirage/ocaml-fat/releases/download/0.12.0/fat-filesystem-0.12.0.tbz"
+checksum: "e69c9b1490cc9c6d16926d683c01b158"

--- a/packages/functoria-runtime/functoria-runtime.2.0.0/url
+++ b/packages/functoria-runtime/functoria-runtime.2.0.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/functoria/archive/2.0.0.tar.gz"
-checksum: "1dcc41302a4b2355bd4e101c1b93cefa"
+archive: "https://github.com/mirage/functoria/releases/download/2.0.0/functoria-runtime-2.0.0.tbz"
+checksum: "139240af0ca1e09b1d30795059d81f52"

--- a/packages/functoria/functoria.2.0.0/url
+++ b/packages/functoria/functoria.2.0.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/functoria/archive/2.0.0.tar.gz"
-checksum: "1dcc41302a4b2355bd4e101c1b93cefa"
+archive: "https://github.com/mirage/functoria/releases/download/2.0.0/functoria-2.0.0.tbz"
+checksum: "ef94680270de7019b7f6970cc0720725"

--- a/packages/mirage-block-lwt/mirage-block-lwt.1.0.0/url
+++ b/packages/mirage-block-lwt/mirage-block-lwt.1.0.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-block/archive/1.0.0.tar.gz"
-checksum: "df1344d0315e90dbf0fbbb1f037316b4"
+archive: "https://github.com/mirage/mirage-block/releases/download/1.0.0/mirage-block-lwt-1.0.0.tbz"
+checksum: "c451b6d5dd1d4e7d6a41b1d378c9b906"

--- a/packages/mirage-block/mirage-block.1.0.0/url
+++ b/packages/mirage-block/mirage-block.1.0.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-block/archive/1.0.0.tar.gz"
-checksum: "df1344d0315e90dbf0fbbb1f037316b4"
+archive: "https://github.com/mirage/mirage-block/releases/download/1.0.0/mirage-block-1.0.0.tbz"
+checksum: "0a2aa26b9ca280c795b3b13f3a36788a"

--- a/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.4.0/url
+++ b/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.4.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-bootvar-xen/archive/0.4.0.tar.gz"
-checksum: "7b291c2332c549ba400f62803b0efa81"
+archive: "https://github.com/mirage/mirage-bootvar-xen/releases/download/0.4.0/mirage-bootvar-xen-0.4.0.tbz"
+checksum: "464459c0b1f83302f254a2b62184a7b1"

--- a/packages/mirage-channel-lwt/mirage-channel-lwt.3.0.0/url
+++ b/packages/mirage-channel-lwt/mirage-channel-lwt.3.0.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-channel/archive/v3.0.0.tar.gz"
-checksum: "67f74edf62292fffc4843bfb099ebbd2"
+archive: "https://github.com/mirage/mirage-channel/releases/download/v3.0.0/mirage-channel-lwt-3.0.0.tbz"
+checksum: "8337ec2339d226bd5c9096fa0f428ecd"

--- a/packages/mirage-channel/mirage-channel.3.0.0/url
+++ b/packages/mirage-channel/mirage-channel.3.0.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-channel/archive/v3.0.0.tar.gz"
-checksum: "67f74edf62292fffc4843bfb099ebbd2"
+archive: "https://github.com/mirage/mirage-channel/releases/download/v3.0.0/mirage-channel-3.0.0.tbz"
+checksum: "b7c56497e88bb6ff7c73bd935968d9b7"

--- a/packages/mirage-clock-freestanding/mirage-clock-freestanding.1.2.0/url
+++ b/packages/mirage-clock-freestanding/mirage-clock-freestanding.1.2.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-clock/archive/1.2.0.tar.gz"
-checksum: "633d190f79c0fce51bc0e0b7a8956593"
+archive: "https://github.com/mirage/mirage-clock/releases/download/1.2.0/mirage-clock-freestanding-1.2.0.tbz"
+checksum: "b4ec7b24345f270e04d94a2f1ed405b7"

--- a/packages/mirage-clock-lwt/mirage-clock-lwt.1.2.0/url
+++ b/packages/mirage-clock-lwt/mirage-clock-lwt.1.2.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-clock/archive/1.2.0.tar.gz"
-checksum: "633d190f79c0fce51bc0e0b7a8956593"
+archive: "https://github.com/mirage/mirage-clock/releases/download/1.2.0/mirage-clock-lwt-1.2.0.tbz"
+checksum: "e791c0a71f29c2cde9239daaa173677d"

--- a/packages/mirage-clock-unix/mirage-clock-unix.1.2.0/url
+++ b/packages/mirage-clock-unix/mirage-clock-unix.1.2.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-clock/archive/1.2.0.tar.gz"
-checksum: "633d190f79c0fce51bc0e0b7a8956593"
+archive: "https://github.com/mirage/mirage-clock/releases/download/1.2.0/mirage-clock-unix-1.2.0.tbz"
+checksum: "1ca490a4572f3bf6a9034842eb092035"

--- a/packages/mirage-clock/mirage-clock.1.2.0/url
+++ b/packages/mirage-clock/mirage-clock.1.2.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-clock/archive/1.2.0.tar.gz"
-checksum: "633d190f79c0fce51bc0e0b7a8956593"
+archive: "https://github.com/mirage/mirage-clock/releases/download/1.2.0/mirage-clock-1.2.0.tbz"
+checksum: "8fcd0b9e05aa62cb75ca7cde8f1bcfeb"

--- a/packages/mirage-console-lwt/mirage-console-lwt.2.2.0/url
+++ b/packages/mirage-console-lwt/mirage-console-lwt.2.2.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-console/archive/2.2.0.tar.gz"
-checksum: "580ce3dab1292fbbd577d213a0d05677"
+archive: "https://github.com/mirage/mirage-console/releases/download/2.2.0/mirage-console-lwt-2.2.0.tbz"
+checksum: "d9333b419b4a300e1113dbadc23ef820"

--- a/packages/mirage-console-unix/mirage-console-unix.2.2.0/url
+++ b/packages/mirage-console-unix/mirage-console-unix.2.2.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-console/archive/2.2.0.tar.gz"
-checksum: "580ce3dab1292fbbd577d213a0d05677"
+archive: "https://github.com/mirage/mirage-console/releases/download/2.2.0/mirage-console-unix-2.2.0.tbz"
+checksum: "56f97bb88c801f96365e8ff715a3c2c6"

--- a/packages/mirage-console-xen-backend/mirage-console-xen-backend.2.2.0/url
+++ b/packages/mirage-console-xen-backend/mirage-console-xen-backend.2.2.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-console/archive/2.2.0.tar.gz"
-checksum: "580ce3dab1292fbbd577d213a0d05677"
+archive: "https://github.com/mirage/mirage-console/releases/download/2.2.0/mirage-console-xen-backend-2.2.0.tbz"
+checksum: "5501ea9766e8765ca7d56928f08f9728"

--- a/packages/mirage-console-xen-cli/mirage-console-xen-cli.2.2.0/url
+++ b/packages/mirage-console-xen-cli/mirage-console-xen-cli.2.2.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-console/archive/2.2.0.tar.gz"
-checksum: "580ce3dab1292fbbd577d213a0d05677"
+archive: "https://github.com/mirage/mirage-console/releases/download/2.2.0/mirage-console-xen-cli-2.2.0.tbz"
+checksum: "cf3855612b3fa4e11eb38f83b6184113"

--- a/packages/mirage-console-xen-proto/mirage-console-xen-proto.2.2.0/url
+++ b/packages/mirage-console-xen-proto/mirage-console-xen-proto.2.2.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-console/archive/2.2.0.tar.gz"
-checksum: "580ce3dab1292fbbd577d213a0d05677"
+archive: "https://github.com/mirage/mirage-console/releases/download/2.2.0/mirage-console-xen-proto-2.2.0.tbz"
+checksum: "112acf1dc797d2f4f2c77a62cd272741"

--- a/packages/mirage-console-xen/mirage-console-xen.2.2.0/url
+++ b/packages/mirage-console-xen/mirage-console-xen.2.2.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-console/archive/2.2.0.tar.gz"
-checksum: "580ce3dab1292fbbd577d213a0d05677"
+archive: "https://github.com/mirage/mirage-console/releases/download/2.2.0/mirage-console-xen-2.2.0.tbz"
+checksum: "8a0fc5a0a0cce21770b4a20fb5fd61dc"

--- a/packages/mirage-console/mirage-console.2.2.0/url
+++ b/packages/mirage-console/mirage-console.2.2.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-console/archive/2.2.0.tar.gz"
-checksum: "580ce3dab1292fbbd577d213a0d05677"
+archive: "https://github.com/mirage/mirage-console/releases/download/2.2.0/mirage-console-2.2.0.tbz"
+checksum: "39d39f371033ebf44f36e0491a00b58c"

--- a/packages/mirage-device/mirage-device.1.0.0/url
+++ b/packages/mirage-device/mirage-device.1.0.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-device/archive/1.0.0.tar.gz"
-checksum: "f89c740c6631f59766c12dfd2e2d18cf"
+archive: "https://github.com/mirage/mirage-device/releases/download/1.0.0/mirage-device-1.0.0.tbz"
+checksum: "6d6f0235b07e1e068ce71d788b5ce11b"

--- a/packages/mirage-flow-lwt/mirage-flow-lwt.1.2.0/url
+++ b/packages/mirage-flow-lwt/mirage-flow-lwt.1.2.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-flow/archive/1.2.0.tar.gz"
-checksum: "edaad00ca5cbe0b843df7969da675b27"
+archive: "https://github.com/mirage/mirage-flow/releases/download/1.2.0/mirage-flow-lwt-1.2.0.tbz"
+checksum: "18b4752fbb9922b57cd25738557b7ef4"

--- a/packages/mirage-flow-unix/mirage-flow-unix.1.2.0/url
+++ b/packages/mirage-flow-unix/mirage-flow-unix.1.2.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-flow/archive/1.2.0.tar.gz"
-checksum: "edaad00ca5cbe0b843df7969da675b27"
+archive: "https://github.com/mirage/mirage-flow/releases/download/1.2.0/mirage-flow-unix-1.2.0.tbz"
+checksum: "c2a40c49fe2a018fe40abd54035c869b"

--- a/packages/mirage-flow/mirage-flow.1.2.0/url
+++ b/packages/mirage-flow/mirage-flow.1.2.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-flow/archive/1.2.0.tar.gz"
-checksum: "edaad00ca5cbe0b843df7969da675b27"
+archive: "https://github.com/mirage/mirage-flow/releases/download/1.2.0/mirage-flow-1.2.0.tbz"
+checksum: "5f603c4a92e6a8681aa7e4b313443f50"

--- a/packages/mirage-fs-lwt/mirage-fs-lwt.1.0.0/url
+++ b/packages/mirage-fs-lwt/mirage-fs-lwt.1.0.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-fs/archive/1.0.0.tar.gz"
-checksum: "0f35d6de5581d389ec4252e324c50184"
+archive: "https://github.com/mirage/mirage-fs/releases/download/1.0.0/mirage-fs-lwt-1.0.0.tbz"
+checksum: "5033652bc40309de77a4986de5bb7a39"

--- a/packages/mirage-fs-unix/mirage-fs-unix.1.3.0/url
+++ b/packages/mirage-fs-unix/mirage-fs-unix.1.3.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-fs-unix/archive/1.3.0.tar.gz"
-checksum: "1dd34e6c7ec1d39b652479dc9ac313bc"
+archive: "https://github.com/mirage/mirage-fs-unix/releases/download/1.3.0/mirage-fs-unix-1.3.0.tbz"
+checksum: "487cd422fdb3040e9d72e598ea02e387"

--- a/packages/mirage-fs/mirage-fs.1.0.0/url
+++ b/packages/mirage-fs/mirage-fs.1.0.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-fs/archive/1.0.0.tar.gz"
-checksum: "0f35d6de5581d389ec4252e324c50184"
+archive: "https://github.com/mirage/mirage-fs/releases/download/1.0.0/mirage-fs-1.0.0.tbz"
+checksum: "66de657d09269608a86b74f25259badc"

--- a/packages/mirage-kv-lwt/mirage-kv-lwt.1.0.0/url
+++ b/packages/mirage-kv-lwt/mirage-kv-lwt.1.0.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-kv/archive/1.0.0.tar.gz"
-checksum: "9663a3e20bc35c2a50760b9b4d8ae295"
+archive: "https://github.com/mirage/mirage-kv/releases/download/1.0.0/mirage-kv-lwt-1.0.0.tbz"
+checksum: "a54daf2fb2be7ff1a0ccabd740ca9d73"

--- a/packages/mirage-kv/mirage-kv.1.0.0/url
+++ b/packages/mirage-kv/mirage-kv.1.0.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-kv/archive/1.0.0.tar.gz"
-checksum: "9663a3e20bc35c2a50760b9b4d8ae295"
+archive: "https://github.com/mirage/mirage-kv/releases/download/1.0.0/mirage-kv-1.0.0.tbz"
+checksum: "51028bd1442e965c193ab0a2d921a72b"

--- a/packages/mirage-logs/mirage-logs.0.3.0/url
+++ b/packages/mirage-logs/mirage-logs.0.3.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-logs/archive/0.3.0.tar.gz"
-checksum: "f06cd5ce5a3e7ebb6d0e4464c2eda308"
+archive: "https://github.com/mirage/mirage-logs/releases/download/0.3.0/mirage-logs-0.3.0.tbz"
+checksum: "7c3dda47d2c5cc2321b3369d66938017"

--- a/packages/mirage-net-lwt/mirage-net-lwt.1.0.0/url
+++ b/packages/mirage-net-lwt/mirage-net-lwt.1.0.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-net/archive/1.0.0.tar.gz"
-checksum: "072326485aa22be4105bd299d8e5277e"
+archive: "https://github.com/mirage/mirage-net/releases/download/1.0.0/mirage-net-lwt-1.0.0.tbz"
+checksum: "b448fe8dd79dffa152ea90add492cd69"

--- a/packages/mirage-net-macosx/mirage-net-macosx.1.3.0/url
+++ b/packages/mirage-net-macosx/mirage-net-macosx.1.3.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-net-macosx/archive/1.3.0.tar.gz"
-checksum: "e8c2a923ed98078b61ba71d00fbac5b8"
+archive: "https://github.com/mirage/mirage-net-macosx/releases/download/1.3.0/mirage-net-macosx-1.3.0.tbz"
+checksum: "5d204011402c27b215cd612b98395f9f"

--- a/packages/mirage-net-unix/mirage-net-unix.2.3.0/url
+++ b/packages/mirage-net-unix/mirage-net-unix.2.3.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-net-unix/archive/2.3.0.tar.gz"
-checksum: "706722ebe8718c5fda55ee889a53c208"
+archive: "https://github.com/mirage/mirage-net-unix/releases/download/2.3.0/mirage-net-unix-2.3.0.tbz"
+checksum: "e4d86201090a649d63a98967b773a5ba"

--- a/packages/mirage-net/mirage-net.1.0.0/url
+++ b/packages/mirage-net/mirage-net.1.0.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-net/archive/1.0.0.tar.gz"
-checksum: "072326485aa22be4105bd299d8e5277e"
+archive: "https://github.com/mirage/mirage-net/releases/download/1.0.0/mirage-net-1.0.0.tbz"
+checksum: "88a3c848b5e7a16973c4161bb304aa52"

--- a/packages/mirage-protocols-lwt/mirage-protocols-lwt.1.0.0/url
+++ b/packages/mirage-protocols-lwt/mirage-protocols-lwt.1.0.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-protocols/archive/1.0.0.tar.gz"
-checksum: "f9d228d2aee00bb7cc4ec32c1641b30a"
+archive: "https://github.com/mirage/mirage-protocols/releases/download/1.0.0/mirage-protocols-lwt-1.0.0.tbz"
+checksum: "be1f49c4a70d2d9740411d9afe502523"

--- a/packages/mirage-protocols/mirage-protocols.1.0.0/url
+++ b/packages/mirage-protocols/mirage-protocols.1.0.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-protocols/archive/1.0.0.tar.gz"
-checksum: "f9d228d2aee00bb7cc4ec32c1641b30a"
+archive: "https://github.com/mirage/mirage-protocols/releases/download/1.0.0/mirage-protocols-1.0.0.tbz"
+checksum: "e9885b8a2306705b57fe6255eba8c4a6"

--- a/packages/mirage-qubes/mirage-qubes.0.4/url
+++ b/packages/mirage-qubes/mirage-qubes.0.4/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-qubes/archive/0.4.tar.gz"
-checksum: "748f5f19949409041e608e6c95ea084a"
+archive: "https://github.com/mirage/mirage-qubes/releases/download/0.4/mirage-qubes-0.4.tbz"
+checksum: "2d7d5b799db7c4b66f59f77d58303ac6"

--- a/packages/mirage-random/mirage-random.1.0.0/url
+++ b/packages/mirage-random/mirage-random.1.0.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-random/archive/1.0.0.tar.gz"
-checksum: "734517976c3da8f82ea1c818268e3801"
+archive: "https://github.com/mirage/mirage-random/releases/download/1.0.0/mirage-random-1.0.0.tbz"
+checksum: "2b377a69264fdab7d6daf552206aae25"

--- a/packages/mirage-runtime/mirage-runtime.3.0.0/url
+++ b/packages/mirage-runtime/mirage-runtime.3.0.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage/archive/v3.0.0.tar.gz"
-checksum: "744cb89c1b35a6d0dadc95ec4ce058c4"
+archive: "https://github.com/mirage/mirage/releases/download/v3.0.0/mirage-runtime-3.0.0.tbz"
+checksum: "02b5d925288087140bb348b68a90199f"

--- a/packages/mirage-stack-lwt/mirage-stack-lwt.1.0.0/url
+++ b/packages/mirage-stack-lwt/mirage-stack-lwt.1.0.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-stack/archive/1.0.0.tar.gz"
-checksum: "7ac6b6a7acd06a429705d32069128258"
+archive: "https://github.com/mirage/mirage-stack/releases/download/1.0.0/mirage-stack-lwt-1.0.0.tbz"
+checksum: "a0d5844664c68a5dd01ea8a151a20804"

--- a/packages/mirage-stack/mirage-stack.1.0.0/url
+++ b/packages/mirage-stack/mirage-stack.1.0.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-stack/archive/1.0.0.tar.gz"
-checksum: "7ac6b6a7acd06a429705d32069128258"
+archive: "https://github.com/mirage/mirage-stack/releases/download/1.0.0/mirage-stack-1.0.0.tbz"
+checksum: "bf6770356418a974d49b9f3cd92883d4"

--- a/packages/mirage-time-lwt/mirage-time-lwt.1.0.0/url
+++ b/packages/mirage-time-lwt/mirage-time-lwt.1.0.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-time/archive/1.0.0.tar.gz"
-checksum: "43b34abe9b7c73efdbbe47961afd5244"
+archive: "https://github.com/mirage/mirage-time/releases/download/1.0.0/mirage-time-lwt-1.0.0.tbz"
+checksum: "191dcbbef64515c3a2663441a31b2087"

--- a/packages/mirage-time/mirage-time.1.0.0/url
+++ b/packages/mirage-time/mirage-time.1.0.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage-time/archive/1.0.0.tar.gz"
-checksum: "43b34abe9b7c73efdbbe47961afd5244"
+archive: "https://github.com/mirage/mirage-time/releases/download/1.0.0/mirage-time-1.0.0.tbz"
+checksum: "e45402238f2c32201e0f6aafe2ef4afe"

--- a/packages/mirage-vnetif/mirage-vnetif.0.3/url
+++ b/packages/mirage-vnetif/mirage-vnetif.0.3/url
@@ -1,2 +1,2 @@
-http: "https://github.com/MagnusS/mirage-vnetif/archive/v0.3.tar.gz"
-checksum: "890bc2ac25caaf4ce0369f84c9ad5715"
+archive: "https://github.com/magnuss/mirage-vnetif/releases/download/v0.3/mirage-vnetif-0.3.tbz"
+checksum: "1381c6539bea3d4e4df45bf3da3438a2"

--- a/packages/mirage/mirage.3.0.0/url
+++ b/packages/mirage/mirage.3.0.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/mirage/mirage/archive/v3.0.0.tar.gz"
-checksum: "744cb89c1b35a6d0dadc95ec4ce058c4"
+archive: "https://github.com/mirage/mirage/releases/download/v3.0.0/mirage-3.0.0.tbz"
+checksum: "a3e7a132e275efd0760bc3515d4f1fb8"


### PR DESCRIPTION
previous URLs pointed to the non-watermarked autogenerated GitHub release (oops), leading to the rather embarrassing

```
mirage --version
%%VERSION_NUM%%
```

Fixes #15 .