### PR TITLE
Add git 1.10.0

### DIFF
--- a/packages/git-http/git-http.1.10.0/descr
+++ b/packages/git-http/git-http.1.10.0/descr
@@ -1,0 +1,1 @@
+Client implementation of the "Smart" HTTP Git protocol in pure OCaml

--- a/packages/git-http/git-http.1.10.0/opam
+++ b/packages/git-http/git-http.1.10.0/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name]
+
+depends: [
+  "git"        {>= "1.10.0"}
+  "cohttp"     {>= "0.19.1"}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/git-http/git-http.1.10.0/url
+++ b/packages/git-http/git-http.1.10.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-git/releases/download/1.10.0/git-1.10.0.tbz"
+checksum: "615a5f1d52836eb6d6f042532fe4c03d"

--- a/packages/git-mirage/git-mirage.1.10.0/descr
+++ b/packages/git-mirage/git-mirage.1.10.0/descr
@@ -1,0 +1,1 @@
+MirageOS backend for the Git protocol(s)

--- a/packages/git-mirage/git-mirage.1.10.0/opam
+++ b/packages/git-mirage/git-mirage.1.10.0/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name "--tests" "false"]
+
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+
+depends: [
+  "mirage-http"
+  "mirage-flow-lwt"
+  "mirage-channel-lwt"
+  "mirage-fs-lwt"
+  "mirage-conduit" {>= "2.3.0"}
+  "result"
+  "git-http" {>= "1.10.0"}
+  "git"      {>= "1.10.0"}
+  "alcotest"       {test}
+  "mirage-fs-unix" {test & >= "1.3.0"}
+]
+
+available: [ocaml-version >= "4.02.3"]

--- a/packages/git-mirage/git-mirage.1.10.0/url
+++ b/packages/git-mirage/git-mirage.1.10.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-git/releases/download/1.10.0/git-1.10.0.tbz"
+checksum: "615a5f1d52836eb6d6f042532fe4c03d"

--- a/packages/git-unix/git-unix.1.10.0/descr
+++ b/packages/git-unix/git-unix.1.10.0/descr
@@ -1,0 +1,5 @@
+Unix backend for the Git protocol(s)
+
+The library comes with a command-line tool called `ogit` which shares
+a similar interface with `git`, but where all operations are mapped to
+the API exposed `ocaml-git` (and hence using only OCaml code).

--- a/packages/git-unix/git-unix.1.10.0/opam
+++ b/packages/git-unix/git-unix.1.10.0/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name "--tests" "false"
+]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+
+depends: [
+  "cmdliner"
+  "git-http" {>= "1.10.0"}
+  "conduit"  {>= "0.8.4"}
+  "camlzip"  {>= "1.06"}
+  "nocrypto" {>= "0.2.0"}
+  "mtime"
+  "base-unix"
+  "alcotest"       {test}
+]
+
+available: [ocaml-version >= "4.02.3"]

--- a/packages/git-unix/git-unix.1.10.0/url
+++ b/packages/git-unix/git-unix.1.10.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-git/releases/download/1.10.0/git-1.10.0.tbz"
+checksum: "615a5f1d52836eb6d6f042532fe4c03d"

--- a/packages/git/git.1.10.0/descr
+++ b/packages/git/git.1.10.0/descr
@@ -1,0 +1,13 @@
+Git format and protocol in pure OCaml
+
+Support for on-disk and in-memory Git stores. Can read and write all
+the Git objects: the usual blobs, trees, commits and tags but also
+the pack files, pack indexes and the index file (where the staging area
+lives).
+
+All the objects share a consistent API, and convenience functions are
+provided to manipulate the different objects. For instance, it is
+possible to make a pack file position independent (as the Zlib
+compression might change the relative offsets between the packed
+objects), to generate pack indexes from pack files, or to expand
+the filesystem of a given commit.

--- a/packages/git/git.1.10.0/opam
+++ b/packages/git/git.1.10.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name]
+
+depends: [
+  "mstruct"    {>= "1.3.1"}
+  "ocamlgraph"
+  "uri"        {>= "1.3.12"}
+  "lwt"        {>= "2.4.7"}
+  "logs"
+  "fmt"
+  "hex"
+  "astring"
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/git/git.1.10.0/url
+++ b/packages/git/git.1.10.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-git/releases/download/1.10.0/git-1.10.0.tbz"
+checksum: "615a5f1d52836eb6d6f042532fe4c03d"


### PR DESCRIPTION
Changelog:

* Adapt to Mirage3 (@samoht, @avsm, @yomimono, @hannesm)
* Add IO.test_and_set to automatically update references (#185, @samoht)
* Better Windows support (#187, @samoht)
  - unix: Translate Git references into valid Windows filenames
  - fix/work-around upstream issues to make the tests pass on Windows
*  Split the package into 4 packages: `git`, `git-http`, `git-unix` and
  `git-mirage` (#189, @samoht)